### PR TITLE
Relu fused

### DIFF
--- a/quantumgrad/cuda/__init__.py
+++ b/quantumgrad/cuda/__init__.py
@@ -1,1 +1,1 @@
-from .wrappers import cpu_to_gpu, gpu_to_cpu, free_gpu_memory, linear
+from .wrappers import cpu_to_gpu, gpu_to_cpu, free_gpu_memory, linear, linear_relu

--- a/quantumgrad/cuda/utils/memory.cu
+++ b/quantumgrad/cuda/utils/memory.cu
@@ -13,6 +13,7 @@
 extern "C" void* allocate_gpu_memory(size_t size) {
     void* ptr;
     CUDA_CHECK(cudaMalloc(&ptr, size));
+    // printf("Allocated GPU memory %p\n", ptr);
     return ptr;
 }
 
@@ -22,13 +23,14 @@ extern "C" void free_gpu_memory(void* ptr) {
 }
 
 extern "C" void copy_cpu_to_gpu(const void* host_data, void* device_data, size_t size) {
+    // printf("CUDA___cpu_to_gpu_______________\n");
     // printf("Device data: %p\n", device_data);
     // printf("Host data: %p\n", host_data);
-    // print size of data to be copied in bytes
+    // // print size of data to be copied in bytes
     // printf("Size: %ld\n", size);
-    // print first 10 elements
+    // // print first 10 elements
     // float* data = (float*)host_data;
-    // printf("CUDA _______________\n");
+    // printf("first 10 elements:\n");
     // for (int i = 0; i < 10; i++) {
     //     printf("%f ", data[i]);
     // }
@@ -38,15 +40,16 @@ extern "C" void copy_cpu_to_gpu(const void* host_data, void* device_data, size_t
 }
 
 extern "C" void copy_gpu_to_cpu(const void* device_data, void* host_data, size_t size) {
-    // print device data which is a pointer
+    // printf("CUDA___gpu_to_cpu_______________\n");
+    // // print device data which is a pointer
     // printf("Device data: %p\n", device_data);
     // printf("Host data: %p\n", host_data);
-    // print size of data to be copied in bytes
+    // // print size of data to be copied in bytes
     // printf("Size: %ld\n", size);
     CUDA_CHECK(cudaMemcpy(host_data, device_data, size, cudaMemcpyDeviceToHost));
     // print first 10 elements
     // float* data = (float*)host_data;
-    // printf("CUDA _______________\n");
+    // printf("first 10 elements:\n");
     // for (int i = 0; i < 10; i++) {
     //     printf("%f ", data[i]);
     // }

--- a/quantumgrad/cuda/wrappers.py
+++ b/quantumgrad/cuda/wrappers.py
@@ -30,6 +30,13 @@ kernel_lib.multiply_add.argtypes = [ctypes.c_void_p,
                                     ctypes.c_int, 
                                     ctypes.c_int]
 
+kernel_lib.multiply_add_relu.argtypes = [ctypes.c_void_p, 
+                                    ctypes.c_void_p, 
+                                    ctypes.c_void_p, 
+                                    ctypes.c_void_p, 
+                                    ctypes.c_int, 
+                                    ctypes.c_int]
+
 util_lib.allocate_gpu_memory.restype = ctypes.c_void_p
 util_lib.allocate_gpu_memory.argtypes = [ctypes.c_size_t]
 
@@ -54,6 +61,7 @@ def cpu_to_gpu(data):
 def gpu_to_cpu(gpu_data, shape):
     # print('cuda wrapper: moving gpu to cpu')
     cpu_data = np.empty(shape, dtype=np.float32)
+    # print('created empty cpu data at', hex(cpu_data.ctypes.data))
     total_elements = np.prod(shape)
     total_size_in_bytes = total_elements * np.float32().nbytes
     util_lib.copy_gpu_to_cpu(gpu_data, cpu_data.ctypes.data, total_size_in_bytes)
@@ -65,7 +73,7 @@ def free_gpu_memory(gpu_data):
 def relu(gpu_data, size):
     kernel_lib.relu_kernel(gpu_data, size)
 
-def linear(gpu_input, gpu_weights, gpu_bias, lrows, lcols, rrows, rcols):
+def linear(gpu_input, gpu_weights, gpu_bias, lrows: int, lcols: int, rrows: int, rcols: int) -> ctypes.c_void_p:
     '''
     Multiplies a matrix by vector and adds a bias.
     Input, weights and bias are all pointers to GPU memory.
@@ -75,7 +83,7 @@ def linear(gpu_input, gpu_weights, gpu_bias, lrows, lcols, rrows, rcols):
     kernel_lib.multiply_add(gpu_input, gpu_weights, gpu_bias, gpu_output, lrows, lcols, rrows, rcols)
     return gpu_output
 
-def linear_relu(gpu_input, gpu_weights, gpu_bias, lrows, lcols, rrows, rcols):
+def linear_relu(gpu_input, gpu_weights, gpu_bias, lrows: int, lcols: int, rrows: int, rcols: int):
     '''
     Multiplies a matrix by vector and adds a bias, then applies ReLU.
     Input, weights and bias are all pointers to GPU memory.

--- a/quantumgrad/cuda/wrappers.py
+++ b/quantumgrad/cuda/wrappers.py
@@ -75,6 +75,15 @@ def linear(gpu_input, gpu_weights, gpu_bias, lrows, lcols, rrows, rcols):
     kernel_lib.multiply_add(gpu_input, gpu_weights, gpu_bias, gpu_output, lrows, lcols, rrows, rcols)
     return gpu_output
 
+def linear_relu(gpu_input, gpu_weights, gpu_bias, lrows, lcols, rrows, rcols):
+    '''
+    Multiplies a matrix by vector and adds a bias, then applies ReLU.
+    Input, weights and bias are all pointers to GPU memory.
+    '''
+    gpu_output = util_lib.allocate_gpu_memory(lrows * rcols * np.float32().nbytes)
+    kernel_lib.multiply_add_relu(gpu_input, gpu_weights, gpu_bias, gpu_output, lrows, lcols, rrows, rcols)
+    return gpu_output
+
 def add_matrices(a, b):
     assert a.shape == b.shape, "Matrices must have the same shape."
 

--- a/quantumgrad/nn/layers/linear.py
+++ b/quantumgrad/nn/layers/linear.py
@@ -35,4 +35,21 @@ class Linear(Module):
             return np.dot(self.weight._data, input) + self.bias._data[:, np.newaxis]
         else:
             return np.dot(self.weight._data, input) + self.bias._data
-    
+        
+    def forward_relu(self, input):
+        if self._device == 'cuda':
+            assert isinstance(input, Tensor), 'Input must be a Tensor'
+            assert input.device == 'cuda', 'Input must be on cuda device'
+            input_rows, input_cols = input.shape
+            out_data = cuda.linear_relu(input._data, 
+                                        self.weight._data, 
+                                        self.bias._data, 
+                                        self.out_features, 
+                                        self.in_features, 
+                                        input_rows, 
+                                        input_cols)
+            return Tensor(out_data, device='cuda', shape=(self.out_features,input_cols))
+        if input.ndim == 2:
+            return np.maximum(0, np.dot(self.weight._data, input) + self.bias._data[:, np.newaxis])
+        else:
+            return np.maximum(0, np.dot(self.weight._data, input) + self.bias._data)

--- a/quantumgrad/tensor.py
+++ b/quantumgrad/tensor.py
@@ -26,6 +26,7 @@ class Tensor:
         
     def __del__(self):
         if self._device == 'cuda':
+            # print('Tensor: Freeing GPU memory')
             cuda.free_gpu_memory(self._data)
         
     @property

--- a/test/test_linear_forward.py
+++ b/test/test_linear_forward.py
@@ -62,6 +62,58 @@ class TestLinearForward(unittest.TestCase):
         np_output = np.dot(cpu_weights_data, np_input) + cpu_nonzeor_bias[:, np.newaxis]
 
         np.testing.assert_allclose(tensor_output.data, np_output, rtol=1e-5, atol=1e-5)
+    
+    def test_linear_forward_relu_cpu(self):
+        linear_layer = nn.Linear(self.input_dim, self.output_dim)
+        x = np.random.rand(self.input_dim).astype(np.float32)
+        y = linear_layer.forward_relu(x)
+        self.assertEqual(y.shape, (self.output_dim,))
+        np_result = np.maximum(0, np.dot(x, linear_layer.weight._data.T) + linear_layer.bias._data)
+        np.testing.assert_allclose(y, np_result, rtol=1e-5, atol=1e-5)
+
+    def test_linear_forward_relu_batch_input_cpu(self):
+        linear_layer = nn.Linear(self.input_dim, self.output_dim)
+        x = np.random.rand(self.input_dim, self.batch_size).astype(np.float32)
+        y = linear_layer.forward_relu(x)
+        self.assertEqual(y.shape, (self.output_dim, self.batch_size))
+        np_result = np.maximum(0, np.dot(linear_layer.weight._data, x) + linear_layer.bias._data[:, np.newaxis])
+        np.testing.assert_allclose(y, np_result, rtol=1e-5, atol=1e-5)
+
+    @unittest.skip("Skip CUDA tests for now")
+    def test_linear_forward_relu_cuda(self):
+        linear_layer = nn.Linear(self.input_dim, self.output_dim)
+        cpu_weights_data = linear_layer.weight.data.copy()
+        cpu_nonzeor_bias = np.random.rand(self.output_dim).astype(np.float32)
+        linear_layer.bias._data = cpu_nonzeor_bias
+
+        linear_layer.to('cuda')
+        self.assertEqual(linear_layer.weight.device, 'cuda')
+
+        np_input = np.random.rand(self.input_dim).astype(np.float32)
+        tensor_input = Tensor(np_input).to('cuda')
+
+        tensor_output = linear_layer.forward_relu(tensor_input).to('cpu')
+        np_output = np.maximum(0, np.dot(np_input, cpu_weights_data.T) + cpu_nonzeor_bias)
+
+        np.testing.assert_allclose(tensor_output.data[:, 0], np_output, rtol=1e-5, atol=1e-5)
+
+    @unittest.skip("Skip CUDA tests for now")
+    def test_linear_forward_relu_batch_input_cuda(self):
+        linear_layer = nn.Linear(self.input_dim, self.output_dim)
+        cpu_weights_data = linear_layer.weight.data.copy()
+        cpu_nonzeor_bias = np.random.rand(self.output_dim).astype(np.float32)
+        linear_layer.bias._data = cpu_nonzeor_bias
+
+        linear_layer.to('cuda')
+        self.assertEqual(linear_layer.weight.device, 'cuda')
+
+        np_input = np.random.rand(self.input_dim, self.batch_size).astype(np.float32)
+        tensor_input = Tensor(np_input).to('cuda')
+
+        tensor_output = linear_layer.forward_relu(tensor_input).to('cpu')
+        np_output = np.maximum(0, np.dot(cpu_weights_data, np_input) + cpu_nonzeor_bias[:, np.newaxis])
+
+        np.testing.assert_allclose(tensor_output.data, np_output, rtol=1e-5, atol=1e-5)
 
 
 if __name__ == '__main__':

--- a/test/test_linear_forward.py
+++ b/test/test_linear_forward.py
@@ -32,8 +32,8 @@ class TestLinearForward(unittest.TestCase):
     def test_linear_forward_cuda(self):
         linear_layer = nn.Linear(self.input_dim, self.output_dim)
         cpu_weights_data = linear_layer.weight.data.copy()
-        cpu_nonzeor_bias = np.random.rand(self.output_dim).astype(np.float32)
-        linear_layer.bias._data = cpu_nonzeor_bias
+        cpu_nonzero_bias = np.random.rand(self.output_dim).astype(np.float32)
+        linear_layer.bias._data = cpu_nonzero_bias
 
         linear_layer.to('cuda')
         self.assertEqual(linear_layer.weight.device, 'cuda')
@@ -42,15 +42,15 @@ class TestLinearForward(unittest.TestCase):
         tensor_input = Tensor(np_input).to('cuda')
 
         tensor_output = linear_layer(tensor_input).to('cpu')
-        np_output = np.dot(np_input, cpu_weights_data.T) + cpu_nonzeor_bias
+        np_output = np.dot(np_input, cpu_weights_data.T) + cpu_nonzero_bias
 
         np.testing.assert_allclose(tensor_output.data[:, 0], np_output, rtol=1e-5, atol=1e-5)
     
     def test_linear_forward_batch_input_cuda(self):
         linear_layer = nn.Linear(self.input_dim, self.output_dim)
         cpu_weights_data = linear_layer.weight.data.copy()
-        cpu_nonzeor_bias = np.random.rand(self.output_dim).astype(np.float32)
-        linear_layer.bias._data = cpu_nonzeor_bias
+        cpu_nonzero_bias = np.random.rand(self.output_dim).astype(np.float32)
+        linear_layer.bias._data = cpu_nonzero_bias
 
         linear_layer.to('cuda')
         self.assertEqual(linear_layer.weight.device, 'cuda')
@@ -59,7 +59,7 @@ class TestLinearForward(unittest.TestCase):
         tensor_input = Tensor(np_input).to('cuda')
 
         tensor_output = linear_layer(tensor_input).to('cpu')
-        np_output = np.dot(cpu_weights_data, np_input) + cpu_nonzeor_bias[:, np.newaxis]
+        np_output = np.dot(cpu_weights_data, np_input) + cpu_nonzero_bias[:, np.newaxis]
 
         np.testing.assert_allclose(tensor_output.data, np_output, rtol=1e-5, atol=1e-5)
     
@@ -79,39 +79,41 @@ class TestLinearForward(unittest.TestCase):
         np_result = np.maximum(0, np.dot(linear_layer.weight._data, x) + linear_layer.bias._data[:, np.newaxis])
         np.testing.assert_allclose(y, np_result, rtol=1e-5, atol=1e-5)
 
-    @unittest.skip("Skip CUDA tests for now")
+    
     def test_linear_forward_relu_cuda(self):
         linear_layer = nn.Linear(self.input_dim, self.output_dim)
         cpu_weights_data = linear_layer.weight.data.copy()
-        cpu_nonzeor_bias = np.random.rand(self.output_dim).astype(np.float32)
-        linear_layer.bias._data = cpu_nonzeor_bias
+        cpu_nonzero_bias = np.random.rand(self.output_dim).astype(np.float32)
+        linear_layer.bias._data = cpu_nonzero_bias
 
         linear_layer.to('cuda')
         self.assertEqual(linear_layer.weight.device, 'cuda')
 
         np_input = np.random.rand(self.input_dim).astype(np.float32)
         tensor_input = Tensor(np_input).to('cuda')
-
-        tensor_output = linear_layer.forward_relu(tensor_input).to('cpu')
-        np_output = np.maximum(0, np.dot(np_input, cpu_weights_data.T) + cpu_nonzeor_bias)
+        
+        tensor_output = linear_layer.forward_relu(tensor_input)
+        tensor_output = tensor_output.to('cpu')
+        
+        np_output = np.maximum(0, np.dot(np_input, cpu_weights_data.T) + cpu_nonzero_bias)
 
         np.testing.assert_allclose(tensor_output.data[:, 0], np_output, rtol=1e-5, atol=1e-5)
 
-    @unittest.skip("Skip CUDA tests for now")
+    # @unittest.skip("Skip CUDA tests for now")
     def test_linear_forward_relu_batch_input_cuda(self):
         linear_layer = nn.Linear(self.input_dim, self.output_dim)
         cpu_weights_data = linear_layer.weight.data.copy()
-        cpu_nonzeor_bias = np.random.rand(self.output_dim).astype(np.float32)
-        linear_layer.bias._data = cpu_nonzeor_bias
+        cpu_nonzero_bias = np.random.rand(self.output_dim).astype(np.float32)
+        linear_layer.bias._data = cpu_nonzero_bias
 
         linear_layer.to('cuda')
         self.assertEqual(linear_layer.weight.device, 'cuda')
 
         np_input = np.random.rand(self.input_dim, self.batch_size).astype(np.float32)
         tensor_input = Tensor(np_input).to('cuda')
-
+        
         tensor_output = linear_layer.forward_relu(tensor_input).to('cpu')
-        np_output = np.maximum(0, np.dot(cpu_weights_data, np_input) + cpu_nonzeor_bias[:, np.newaxis])
+        np_output = np.maximum(0, np.dot(cpu_weights_data, np_input) + cpu_nonzero_bias[:, np.newaxis])
 
         np.testing.assert_allclose(tensor_output.data, np_output, rtol=1e-5, atol=1e-5)
 


### PR DESCRIPTION
### Enable ReLU fused kernel

- add multiply-add-relu fused CUDA kernel
- add wrapper for this kernel
- add a `.forward_relu()` method in Linear class
- add tests for Linear.forward_relu() on cpu and CUDA